### PR TITLE
Use mailgun to send notifications

### DIFF
--- a/.github/workflows/run_hall_monitor_mplp.yml
+++ b/.github/workflows/run_hall_monitor_mplp.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "http://da-dev.mplp.org/"
+          MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
+          MAILGUN_DOMAIN: ${{ secrets.MAILGUN_DOMAIN }}
+          ERROR_EMAILS: ${{ secrets.ERROR_EMAILS }}
+          ERROR_EMAIL_FROM: ${{ secrets.ERROR_EMAIL_FROM }}
       - run: echo "Finished running monitor for dev"
   prod-monitor:
     runs-on: ubuntu-latest
@@ -22,4 +26,8 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "http://da-prod.mplp.org/"
+          MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
+          MAILGUN_DOMAIN: ${{ secrets.MAILGUN_DOMAIN }}
+          ERROR_EMAILS: ${{ secrets.ERROR_EMAILS }}
+          ERROR_EMAIL_FROM: ${{ secrets.ERROR_EMAIL_FROM }}
       - run: echo "Finished running monitor for prod"


### PR DESCRIPTION
With https://github.com/SuffolkLITLab/ALActions/pull/15 merged, we can use Mailgun to send error notification emails now!

There are a few secrets that need to be set in GitHub for this to work:

* MAILGUN_API_KEY: can be the domain sending key, or the full API key
* MAILGUN_DOMAIN
* ERROR_EMAILS: a comma separated list of the emails we want to get notifications for something going wrong with the servers.
* ERROR_EMAIL_FROM: the email with want to send the message from. Can be the name convention, "John Brown <example@example.com>", so the email is easier to recoginize. Also important to make sure that the message is sent from an authorized sender so it doesn't get filtered a spam (which kept happening with my gmail).

[GitHub's documenation for secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) will help when setting those up. Since we have a repository for maintenance stuff, I recommend making the repo secrets. We can always make them organization secrets later, but better to keep things scoped for now.

Happy to hop on a call to discuss more or help out setting up at all.